### PR TITLE
Fixed bugs in wallet details

### DIFF
--- a/screens/Home/CardItem.tsx
+++ b/screens/Home/CardItem.tsx
@@ -19,7 +19,7 @@ const {width: viewportWidth} = Dimensions.get('window');
 export default ({wallet, noAction = false, cardId}: {
 	wallet: any
 	noAction?: boolean;
-	cardId?: number;
+	cardId: number;
 }) => {
 	const theme = useContext(ThemeContext);
 	const tokenInfo = useRecoilValue(tokenInfoAtom);
@@ -54,7 +54,7 @@ export default ({wallet, noAction = false, cardId}: {
 			<View style={styles.kaiCard}>
 				<Image
 					style={[styles.cardBackground, {width: viewportWidth - 40}]}
-					source={parseCardAvatar(cardId || wallet.cardAvatarID)}
+					source={parseCardAvatar(cardId)}
 					// source={require('../../assets/test.jpg')}
 				/>
 				<View

--- a/screens/Home/CardSliderSection.tsx
+++ b/screens/Home/CardSliderSection.tsx
@@ -19,7 +19,7 @@ const CardSliderSection = () => {
   const [snapTimeoutId, setSnapTimeoutId] = useState<any>()
 
   const renderWalletItem = ({item: wallet}: any) => {
-    return <CardItem wallet={wallet} />
+    return <CardItem wallet={wallet} cardId={wallet.cardAvatarID} />
   };
 
   useEffect(() => {

--- a/screens/WalletDetail/index.tsx
+++ b/screens/WalletDetail/index.tsx
@@ -98,7 +98,7 @@ export default () => {
     return () =>
       BackHandler.removeEventListener('hardwareBackPress', onBackPress);
 
-  }, []);
+  }, [name, cardAvatarID]);
 
   if (!wallet) {
     return null;

--- a/screens/WalletDetail/index.tsx
+++ b/screens/WalletDetail/index.tsx
@@ -49,9 +49,9 @@ export default () => {
   const wallet = wallets.find((w) => w.address === address);
 
   const [name, setName] = useState(wallet ? wallet.name : '');
-  const [cardAvatarID, setCardAvatarID] = useState(wallet ? wallet.cardAvatarID : 1);
+  const [cardAvatarID, setCardAvatarID] = useState(wallet ? wallet.cardAvatarID : 0);
 
-  const krc20Prices = useRecoilValue(krc20PricesAtom);;
+  const krc20Prices = useRecoilValue(krc20PricesAtom);
   const tokenList = useRecoilValue(filterByOwnerSelector(wallets[selectedWallet].address))
   const [KRC20Balance, setKRC20Balance] = useState(0)
 
@@ -183,7 +183,7 @@ export default () => {
         >
           <TouchableWithoutFeedback onPress={() => Keyboard.dismiss()}>
             <View style={{ paddingHorizontal: 20 }}>
-              <CardItem wallet={wallet} noAction={true} cardId={cardAvatarID} />
+              <CardItem wallet={wallet} noAction={true} cardId={cardAvatarID || 0} />
               <CustomText style={{ color: theme.textColor, fontSize: 20, fontWeight: 'bold', marginTop: 20 }}>
                 {getLanguageString(language, 'WALLET_DETAILS')}
               </CustomText>


### PR DESCRIPTION
Fixed two minor issues I found in the wallet details screen:

1. Wallet details were not saved on the hardware back press

2. When any other card type was set, but 'Dark Galaxy' (for example 'Blue Ocean') and wallet details screen was open if the user clicked back on 'Dark Galaxy' -> CardItem at the top will not update. (Note: it will be saved if navigated back from the screen, but at the moment when that card type is clicked, it will not update)